### PR TITLE
fix passthrough baud assumption

### DIFF
--- a/lib/CrsfSerial/CrsfSerial.cpp
+++ b/lib/CrsfSerial/CrsfSerial.cpp
@@ -31,12 +31,12 @@
 // }
 
 CrsfSerial::CrsfSerial(HardwareSerial &port, uint32_t baud) :
-    _port(port), _crc(0xd5),
+    _port(port), _crc(0xd5), _baud(baud),
     _lastReceive(0), _lastChannelsPacket(0), _linkIsUp(false),
     _passthroughMode(false)
 {
     // Crsf serial is 420000 baud for V2
-    _port.begin(baud);
+    _port.begin(_baud);
 }
 
 // Call from main loop to update
@@ -246,5 +246,5 @@ void CrsfSerial::setPassthroughMode(bool val, unsigned int baud)
     if (baud != 0)
         _port.begin(baud);
     else
-        _port.begin(CRSF_BAUDRATE);
+        _port.begin(_baud);
 }

--- a/lib/CrsfSerial/CrsfSerial.h
+++ b/lib/CrsfSerial/CrsfSerial.h
@@ -40,6 +40,7 @@ private:
     uint8_t _rxBufPos;
     Crc8 _crc;
     crsfLinkStatistics_t _linkStatistics;
+    uint32_t _baud;
     uint32_t _lastReceive;
     uint32_t _lastChannelsPacket;
     bool _linkIsUp;


### PR DESCRIPTION
The setPassthroughMode makes the assumption that the baud rate is CRSF_BAUDRATE even if the CrsfSerial object was instantiated with a different baud.

This should fix that and use the baud rate that was requested on instantiating, but default back to CRSF_BAUDRATE if no baud rate is given.