### PR TITLE
Change CH3 failsafe default to 1500

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -11,7 +11,7 @@
 constexpr int OUTPUT_MAP[NUM_OUTPUTS] = { 1, 2, 3, 4, 6, 7, 8, 12 };
 // The failsafe action for each channel (fsaNoPulses, fsaHold, or microseconds)
 constexpr int OUTPUT_FAILSAFE[NUM_OUTPUTS] = {
-    1500, 1500, 988, 1500,                  // ch1-ch4
+    1500, 1500, 1500, 1500,                  // ch1-ch4
     fsaHold, fsaHold, fsaHold, fsaNoPulses  // ch5-ch8
     };
 // Define the pins used to output servo PWM, must use hardware PWM,


### PR DESCRIPTION
This changes the default failsafe for channel 3 to 1500, which might be safer for most people.

I didn't pay too much attention to the failsafe values and my boat actually used half power once it failsafed. 