### PR TITLE
Add support for arm/disarm switch

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ The code has failsafe detection which happens if no channel packets are received
 
 ### Arming / Disarming
 
-CRServoF includes an optional feature to require an arming signal for other channels to be processed. To use this feature, include the buildflag `USE_ARMSWITCH`. CRServoF expects a value of 2000 on CH5 to arm and any other value to disarm. If disarmed, the failsafe values mentioned above will be sent, make sure that you use the correct values applicable to your use case.
+CRServoF includes an optional feature to require an arming signal for other channels to be processed. To use this feature, include the buildflag `USE_ARMSWITCH`. CRServoF expects a "high" value (>1500us) on CH5 to arm. If disarmed, the failsafe values mentioned above will be sent, make sure that you use the correct values applicable to your use case.
 
 ### VBAT
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ The code has failsafe detection which happens if no channel packets are received
 
 ### Arming / Disarming
 
-CRServoF includes an optional feature to require an arming signal for other channels to be processed. To use this feature, include the buildflag `ARMSWITCH`. CRServoF expects a value of 2000 on CH5 to arm and any other value to disarm. If disarmed, the failsafe values mentioned above will be sent, make sure that you use the correct values applicable to your use case.
+CRServoF includes an optional feature to require an arming signal for other channels to be processed. To use this feature, include the buildflag `USE_ARMSWITCH`. CRServoF expects a value of 2000 on CH5 to arm and any other value to disarm. If disarmed, the failsafe values mentioned above will be sent, make sure that you use the correct values applicable to your use case.
 
 ### VBAT
 

--- a/README.md
+++ b/README.md
@@ -20,13 +20,17 @@ To change the channel mapping, use the `OUTPUT_MAP[]` array at the top. These ar
 
 The code has failsafe detection which happens if no channel packets are received for a short time (300ms currently). The default failsafe setting is to set CH1-4 to `1500, 1500, 988, 1500`, CH4-7 to hold their last position, and CH8 to stop putting out pulses. To change the failsafe behavior, modify the `OUTPUT_FAILSAFE[]` array with either the microseconds position to set on failsafe or `fsaNoPulses` (stop outputting PWM) or `fsaHold` (hold last received value).
 
+### Arming / Disarming
+
+CRServoF includes an optional feature to require an arming signal for other channels to be processed. To use this feature, include the buildflag `ARMSWITCH`. CRServoF expects a value of 2000 on CH5 to arm and any other value to disarm. If disarmed, the failsafe values mentioned above will be sent, make sure that you use the correct values applicable to your use case.
+
 ### VBAT
 
 The code sends a BATTERY telemetry item back to the CRSF RX, using A0 as the input value. **You can not plug VBAT directly in**. The maximum input voltage is 3.3V so the voltage needs to be scaled down. The code expects a resistor divider `VBAT -- 8.2kohm -A0- 1.2kohm -- GND` with VBAT on one end, GND on the other, and A0 connected in the middle. That should be good up to 6S voltage if I did my math right. The voltage can be calibrated using the `VBAT_SCALE` define in the top of main.cpp, and different resistors can be used by changing the `VBAT_R1` and `VBAT_R2` defines.
 
 ### ExpressLRS_via_BetaflightPassthrough
 
-The serial UART will attempt to emulate a Betaflight CLI so ExpressLRS can flash the connected RX with yet another RC version. This works, I dunno, like 80% of the time? It is hard to get all the timing just right, but if it fails, you'l likely need to repower the whole device because the RX is in the bootloader and probably at the wrong autobaud.
+The serial UART will attempt to emulate a Betaflight CLI so ExpressLRS can flash the connected RX with yet another RC version. This works, I dunno, like 80% of the time? It is hard to get all the timing just right, but if it fails, you will likely need to repower the whole device because the RX is in the bootloader and probably at the wrong autobaud.
 
 
 

--- a/platformio.ini
+++ b/platformio.ini
@@ -25,3 +25,14 @@ build_flags = ${env_common.build_flags_cdc}
 extends = env_common
 build_flags = ${env_common.build_flags_cdc}
    -DTARGET_PURPLEPILL
+   
+   
+# The build flag ARMSWITCH expects a value of 2000 (armed) or 1000 (disarmed)
+# on channel 5. As long as the controller does not send the "armed" state,
+# all channels will receive the values specified in OUTPUT_FAILSAFE instead
+[env:F103_serial_armswitch]
+extends = env_common
+build_flags = ${env_common.build_flags_cdc}
+    -DTARGET_BLUEPILL
+    -DARMSWITCH
+

--- a/platformio.ini
+++ b/platformio.ini
@@ -33,6 +33,6 @@ build_flags = ${env_common.build_flags_cdc}
 # Before using this option, make sure that your failsafe values are correct!
 [env:F103_serial_armswitch]
 extends = env:F103_serial
-build_flags = ${env:F103_serial.build_flags]
+build_flags = ${env:F103_serial.build_flags}
   -DUSE_ARMSWITCH
 

--- a/platformio.ini
+++ b/platformio.ini
@@ -32,8 +32,7 @@ build_flags = ${env_common.build_flags_cdc}
 # all channels will receive the values specified in OUTPUT_FAILSAFE instead.
 # Before using this option, make sure that your failsafe values are correct!
 [env:F103_serial_armswitch]
-extends = env_common
-build_flags = ${env_common.build_flags_cdc}
-    -DTARGET_BLUEPILL
-    -DARMSWITCH
+extends = env:F103_serial
+build_flags = ${env:F103_serial.build_flags]
+  -DUSE_ARMSWITCH
 

--- a/platformio.ini
+++ b/platformio.ini
@@ -29,7 +29,8 @@ build_flags = ${env_common.build_flags_cdc}
    
 # The build flag ARMSWITCH expects a value of 2000 (armed) or 1000 (disarmed)
 # on channel 5. As long as the controller does not send the "armed" state,
-# all channels will receive the values specified in OUTPUT_FAILSAFE instead
+# all channels will receive the values specified in OUTPUT_FAILSAFE instead.
+# Before using this option, make sure that your failsafe values are correct!
 [env:F103_serial_armswitch]
 extends = env_common
 build_flags = ${env_common.build_flags_cdc}

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -105,6 +105,7 @@ static void outputFailsafeValues()
             armCount++;
             return false;
         }
+        return true;
     }
 #endif
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -78,14 +78,31 @@ static void outputFailsafeValues()
 }
 
 
+#if defined(ARMSWITCH)
+    short armCount = 0;
+#endif
+
 static void packetChannels()
 {
-
     #if defined(ARMSWITCH)
-        if (crsf.getChannel(5) < 2000)
+        // If channel 5 doesn't send "arm" signal (value 2000), output failsafe only
+        if (crsf.getChannel(5) != 2000)
         {
             outputFailsafeValues();
+            armCount = 0;
             return;
+        } 
+        else
+        {
+            // Require at least 4 packets with "arm" signal, in order to
+            // prevent accidental arming due to corrupt signals, similar
+            // to Betaflight
+            if (armCount < 4)
+            {
+                outputFailsafeValues();
+                armCount++;
+                return;
+            }
         }
     #endif
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -144,7 +144,7 @@ static void outputFailsafeValues()
     // checks if the arm signal was sent on channel defined by CRSF_ELRS_ARM_CHANNEL.
     // The arm signal has to be value 2000
     static bool isMotorArmed()
-    	{
+    {
     	// Static variable to store arm count, initialized to 0
         static uint8_t armCount = 0;
         


### PR DESCRIPTION
This adds support for an arm switch, which according to ELRS specs should be sent on channel 5. All other outputs default to failsafe, when no arm signal has been received